### PR TITLE
Pronto summarizer

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -36,6 +36,7 @@ class Parser
 
   def add_stat(raw_hash)
     attrs = StationMapper.new(raw_hash).remap.slice(*stat_fields)
+    attrs.merge!(timestamp: timestamp)
     station = Station.find_by(pronto_id: attrs.delete('pronto_id'))
     StationStat.create!(attrs.merge(station: station))
   end

--- a/lib/pronto_summarizer.rb
+++ b/lib/pronto_summarizer.rb
@@ -12,4 +12,8 @@ class ProntoSummarizer
       StatSummarizer.new(stat).summarize
     end
   end
+
+  def clean
+    StationStat.where('timestamp <= ?', @timestamp - 100).destroy_all
+  end
 end

--- a/lib/pronto_summarizer.rb
+++ b/lib/pronto_summarizer.rb
@@ -1,0 +1,9 @@
+class ProntoSummarizer
+  def initialize(timestamp)
+    @timestamp = timestamp
+  end
+
+  def stats
+    StationStat.where(timestamp: @timestamp)
+  end
+end

--- a/lib/pronto_summarizer.rb
+++ b/lib/pronto_summarizer.rb
@@ -6,4 +6,10 @@ class ProntoSummarizer
   def stats
     StationStat.where(timestamp: @timestamp)
   end
+
+  def summarize
+    stats.each do |stat|
+      StatSummarizer.new(stat).summarize
+    end
+  end
 end

--- a/lib/pronto_summarizer.rb
+++ b/lib/pronto_summarizer.rb
@@ -16,4 +16,8 @@ class ProntoSummarizer
   def clean
     StationStat.where('timestamp <= ?', @timestamp - 100).destroy_all
   end
+
+  def update
+    summarize && clean
+  end
 end

--- a/lib/tasks/snp.rake
+++ b/lib/tasks/snp.rake
@@ -1,5 +1,8 @@
 desc "Scrapes and parses Pronto API"
 task :snp => :environment do
   Scraper.new.download
-  Parser.new.parse
+  p = Parser.new
+  p.parse
+  updater = ProntoSummarizer.new(p.timestamp)
+  updater.update
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Parser do
-  let(:parser) { Parser.new }
+  let(:parser) { Parser.new('spec/fixtures/pronto_scrape.txt') }
 
   describe "#parse" do
     it "changes count" do
@@ -9,13 +9,13 @@ RSpec.describe Parser do
     end
 
     it "doesn't create new stations when they exist" do
-      Station.create!(pronto_id: 66)
+      create(:station)
       expect{ parser.parse }.to change{ Station.count }.by(53)
       expect(Station.count).to eq(54)
     end
 
     it "updates pre-existing station" do
-      s = Station.create!(pronto_id: 66)
+      s = create(:station)
       expect(s.blocked).to eq(nil)
       parser.parse
       expect(s.reload.blocked).to eq(false)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Parser do
     end
 
     it "doesn't create new stations when they exist" do
-      create(:station)
+      create(:station, pronto_id: 66)
       expect{ parser.parse }.to change{ Station.count }.by(53)
       expect(Station.count).to eq(54)
     end
 
     it "updates pre-existing station" do
-      s = create(:station)
+      s = create(:station, pronto_id: 66)
       expect(s.blocked).to eq(nil)
       parser.parse
       expect(s.reload.blocked).to eq(false)

--- a/spec/pronto_summarizer_spec.rb
+++ b/spec/pronto_summarizer_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ProntoSummarizer do
+  describe "#stats" do
+    let(:parser) { Parser.new('spec/fixtures/pronto_scrape.txt') }
+    let(:summarizer) { ProntoSummarizer.new(parser.timestamp) }
+
+    it "gathers StationStats" do
+      parser.parse
+      expect(summarizer.stats.size).to eq(54)
+    end
+  end
+
+  xit "removes StationStats older than 1 hour"
+  xit "summarizes each StationStat"
+end

--- a/spec/pronto_summarizer_spec.rb
+++ b/spec/pronto_summarizer_spec.rb
@@ -1,16 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe ProntoSummarizer do
-  describe "#stats" do
-    let(:parser) { Parser.new('spec/fixtures/pronto_scrape.txt') }
-    let(:summarizer) { ProntoSummarizer.new(parser.timestamp) }
+  let(:summarizer) { ProntoSummarizer.new(700) }
 
+  before do
+    54.times { create(:station_stat, timestamp: 700) }
+  end
+
+  describe "#stats" do
     it "gathers StationStats" do
-      parser.parse
       expect(summarizer.stats.size).to eq(54)
     end
   end
 
+  describe "#summarize" do
+    let(:stat_sum) { double(StatSummarizer) }
+
+    it "summarizes each StationStat" do
+      allow(StatSummarizer).to receive(:new).and_return(stat_sum)
+      expect(stat_sum).to receive(:summarize).exactly(54).times
+      summarizer.summarize
+    end
+  end
+
   xit "removes StationStats older than 1 hour"
-  xit "summarizes each StationStat"
 end

--- a/spec/pronto_summarizer_spec.rb
+++ b/spec/pronto_summarizer_spec.rb
@@ -23,5 +23,16 @@ RSpec.describe ProntoSummarizer do
     end
   end
 
-  xit "removes StationStats older than 1 hour"
+  describe "#clean" do
+    before do
+      54.times { create(:station_stat, timestamp: 559) }
+    end
+
+    it "removes StationStats older than 1 hour" do
+      old_stats = StationStat.where('timestamp <= ?', 600)
+      expect(old_stats.size).to eq(54)
+      summarizer.clean
+      expect(old_stats.reload).to be_blank
+    end
+  end
 end

--- a/spec/pronto_summarizer_spec.rb
+++ b/spec/pronto_summarizer_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe ProntoSummarizer do
       expect(old_stats.reload).to be_blank
     end
   end
+
+  describe "#update" do
+    after do
+      summarizer.update
+    end
+
+    it "calls summarize" do
+      expect(summarizer).to receive(:summarize)
+    end
+
+    it "calls clean" do
+      expect(summarizer).to receive(:clean)
+    end
+  end
 end

--- a/spec/scraper_spec.rb
+++ b/spec/scraper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Scraper do
   describe "#download" do
-    before(:all) do
+    before do
       VCR.use_cassette("pronto_text") do
         scraper = Scraper.new
         scraper.download

--- a/spec/station_mapper_spec.rb
+++ b/spec/station_mapper_spec.rb
@@ -24,18 +24,16 @@ RSpec.describe StationMapper do
   end
 
   describe "#remap" do
-    before(:all) do
-      json = JSON.parse(File.open('spec/fixtures/station.json','r').read)
-      @mapper = StationMapper.new(json)
-    end
+    let(:json) { JSON.parse(File.open('spec/fixtures/station.json','r').read) }
+    let(:mapper) { StationMapper.new(json) }
 
     it "converts raw keys to mapped keys" do
       keys = StationMapper::MAPPINGS.values
-      expect(@mapper.remap.keys).to eq(keys)
+      expect(mapper.remap.keys).to eq(keys)
     end
 
     it "converts datetime values" do
-      dt_values = @mapper.remap.values_at(*StationMapper::DATETIME_FIELDS)
+      dt_values = mapper.remap.values_at(*StationMapper::DATETIME_FIELDS)
 
       dt_values.each do |val|
         expect(val).to be_a(Time)


### PR DESCRIPTION
Implements ProntoSummarizer, which updates all StationSummaries and removes old StationStats. Other changes:
- `Parser#parse` adds timestamp to `StationStats`
- `rake snp` task updated
- Tweak parser_spec for repeatability
- Remove `before(:all)` blocks to ensure succesful passing of testsin keeping with database_cleaner settings
